### PR TITLE
Fix #121 add node to group

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -387,6 +387,7 @@ func (n *Node) groupAddNode(g *cronsun.Group) {
 			}
 
 			job.Init(n.ID, n.Hostname, n.IP)
+			n.jobs[jid] = job
 		}
 
 		cmds := job.Cmds(n.ID, n.groups)


### PR DESCRIPTION
修复 #121 的bug。
重现步骤：

1. 新建节点分组`节点分组1`；
2. 新建任务，并且选择 `节点分组1`；
3. 开启任务；
4. 起cronnode新加节点 -> 修改节点分组把新节点加入到`节点分组1`；
5. 暂停 任务，可以发现任务在新加的节点上面继续调度，并不会暂停；