### PR TITLE
fix: Replace Username with FromEmail for warning email

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -118,6 +118,8 @@ type MailConf struct {
 	HttpAPI string
 	// 如果此时间段内没有邮件发送，则关闭 SMTP 连接，单位/秒
 	Keepalive int64
+	// sender email of warning email.
+	FromEmail string
 	*gomail.Dialer
 }
 

--- a/conf/files/mail.json.sample
+++ b/conf/files/mail.json.sample
@@ -11,5 +11,7 @@
     "Password": "nbhh",
     "SSL": false,
     "#LocalName": "LocalName is the hostname sent to the SMTP server with the HELO command. By default, 'localhost' is sent.",
-    "LocalName": "localhost"
+    "LocalName": "localhost",
+    "#FromEmail": "FromEmail is the email address of warning email sent from when warning email is enabled.",
+    "FromEmail": "no-reply@local.com"
 }

--- a/noticer.go
+++ b/noticer.go
@@ -83,7 +83,7 @@ func (m *Mail) Serve() {
 			}
 
 			sm.Reset()
-			sm.SetHeader("From", m.cf.Username)
+			sm.SetHeader("From", m.cf.FromEmail)
 			sm.SetHeader("To", msg.To...)
 			sm.SetHeader("Subject", msg.Subject)
 			sm.SetBody("text/plain", msg.Body)


### PR DESCRIPTION
修复[issue-87](https://github.com/shunfei/cronsun/issues/87) 里提到的错误：
err: gomail: could not send email 1: gomail: invalid address "bbxxxfe": mail: no angle-addr