### PR TITLE
修改etcd go mod 的地址

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ web/ui/dist
 .vscode
 *npm-debug.log
 vendor
+.idea/

--- a/go.mod
+++ b/go.mod
@@ -58,3 +58,5 @@ require (
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
 )
+
+replace github.com/coreos/etcd v3.3.9+incompatible => go.etcd.io/etcd v3.3.9+incompatible

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/ugorji/go/codec v0.0.0-20180831062425-e253f1f20942 h1:CZORS/4d6i+5FKS
 github.com/ugorji/go/codec v0.0.0-20180831062425-e253f1f20942/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 h1:MPPkRncZLN9Kh4MEFmbnK4h3BD7AUmskWv2+EeZJCCs=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+go.etcd.io/etcd v3.3.9+incompatible h1:9dBehkvrIIwxqtxalmThfTAUnEqep3nD9ewq/HMsQeY=
+go.etcd.io/etcd v3.3.9+incompatible/go.mod h1:yaeTdrJi5lOmYerz05bd8+V7KubZs8YSFZfzsF9A6aI=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=


### PR DESCRIPTION
replace github.com/coreos/etcd  to  go.etcd.io/etcd 

- [etcd go mod 地址](https://github.com/etcd-io/etcd/blob/master/go.mod#L1)