### PR TITLE
1、修复当数据库过大时，前端默认没有选择日期，导致的查询超时问题。增加了前端默认选择日期为当前日期

### DIFF
--- a/web/ui/src/components/Log.vue
+++ b/web/ui/src/components/Log.vue
@@ -103,6 +103,13 @@ export default {
       var vm = this;
       $(this.$refs.latest).checkbox();
       $(this.$refs.failedOnly).checkbox();
+
+      // 挂载时，初始化日期选择为当前日志，防止大数据量的时候，用户无差别请求导致的io超时
+      const time = new Date();
+      const day = ("0" + time.getDate()).slice(-2);
+      const month = ("0" + (time.getMonth() + 1)).slice(-2);
+      const today = time.getFullYear() + "-" + (month) + "-" + (day);
+      this.begin = this.end = today;
   },
 
   watch: {


### PR DESCRIPTION
生产环境当中，数据量为500w，用户经常性的点击查询，会经常出现io查询超时问题。默认当前日期可以解决无差别请求问题，增强用户体验